### PR TITLE
Add support for deploying external installer outside Jenkins

### DIFF
--- a/deploy_mac.py
+++ b/deploy_mac.py
@@ -5,8 +5,6 @@ It expects the following environment variable be provided:
 - BUILD_TYPE : Build type [Win64, Win32, Linux, MacOS]
 - WORKSPACE : Jenkins workspace (set by jenkins itself)
 """
-from __future__ import print_function
-
 import os
 import time
 
@@ -29,7 +27,7 @@ if __name__ == '__main__':
     APP_PATH = os.path.join(os.environ.get('WORKSPACE'), "Tribler.app")
 
     # Step 2: check SHA256 hash
-    if not check_sha256_hash(INSTALLER_FILE, HASH):
+    if HASH and not check_sha256_hash(INSTALLER_FILE, HASH):
         print_and_exit("SHA256 of file does not match with target hash %s" % HASH)
 
     # Step 3: Mount the dmg file

--- a/deploy_ubuntu.py
+++ b/deploy_ubuntu.py
@@ -10,8 +10,6 @@ variable be provided:
 - WORKSPACE : Jenkins workspace (set by jenkins itself)
 - TRIBLER_PASSWORD : Local user password
 """
-from __future__ import print_function
-
 import os
 import time
 
@@ -32,7 +30,7 @@ if __name__ == '__main__':
     INSTALLER_FILE, HASH = fetch_latest_build_artifact(job_url, build_type)
 
     # Step 2: check SHA256 hash
-    if not check_sha256_hash(INSTALLER_FILE, HASH):
+    if HASH and not check_sha256_hash(INSTALLER_FILE, HASH):
         print_and_exit("SHA256 of file does not match with target hash %s" % HASH)
 
     # Step 3: Remove dpkg lock if exists

--- a/deploy_windows.py
+++ b/deploy_windows.py
@@ -6,8 +6,6 @@ variable:
 - BUILD_TYPE : Build type [Win64, Win32, Linux, MacOS]
 - WORKSPACE : Jenkins workspace (set by jenkins itself)
 """
-from __future__ import print_function
-
 import os
 import time
 
@@ -28,10 +26,10 @@ if __name__ == '__main__':
     INSTALLER_FILE, HASH = fetch_latest_build_artifact(job_url, build_type)
 
     # Step 2: check SHA256 hash
-    if not check_sha256_hash(INSTALLER_FILE, HASH):
+    if HASH and not check_sha256_hash(INSTALLER_FILE, HASH):
         print("SHA256 of file does not match with target hash %s, we retry to download it" % HASH)
         INSTALLER_FILE, HASH = fetch_latest_build_artifact(job_url, build_type)
-        if not check_sha256_hash(INSTALLER_FILE, HASH):
+        if HASH and not check_sha256_hash(INSTALLER_FILE, HASH):
             print_and_exit("Download seems to be really broken, bailing out")
 
     success_install = False

--- a/deployment_utils.py
+++ b/deployment_utils.py
@@ -51,7 +51,8 @@ def check_sha256_hash(file_path, target_sha256_hash):
 
 def get_artifact_extension(build_type):
     build_type = build_type.lower()
-    return '.exe' if build_type in ['win64', 'win32'] \
+    return '_x64.exe' if build_type == 'win64' \
+        else 'x86.exe' if build_type == 'win32' \
         else '.deb' if build_type == 'linux' \
         else '.dmg' if build_type == 'macos' \
         else None

--- a/deployment_utils.py
+++ b/deployment_utils.py
@@ -3,12 +3,11 @@ Utility script to fetch the latest build artifact from Jenkins. It expects the f
 Not it expects following environment variables:
 - WORKSPACE : Jenkins workspace (set by jenkins itself)
 """
-from __future__ import print_function
-
 import hashlib
 import json
 import os
 import sys
+from urllib.parse import urlparse, ParseResult
 
 import requests
 import sentry_sdk
@@ -50,39 +49,89 @@ def check_sha256_hash(file_path, target_sha256_hash):
     return hex_sha256_hash == target_sha256_hash
 
 
-def fetch_latest_build_number(job_url):
-    build_json = json.loads(requests.get('%s/api/json' % job_url).text)
-    return build_json['lastCompletedBuild']['number']
+def get_artifact_extension(build_type):
+    build_type = build_type.lower()
+    return '.exe' if build_type in ['win64', 'win32'] \
+        else '.deb' if build_type == 'linux' \
+        else '.dmg' if build_type == 'macos' \
+        else None
+
+
+def is_valid_artifact_url(parsed_url: ParseResult, build_type: str) -> bool:
+    scheme = parsed_url.scheme
+    if parsed_url.netloc and scheme and (scheme == 'http' or scheme == 'https'):
+        extension = get_artifact_extension(build_type)
+        if extension and parsed_url.path.endswith(extension):
+            return True
+    return False
+
+
+def is_valid_jenkins_url(parsed_url: ParseResult) -> bool:
+    location = parsed_url.netloc
+    scheme = parsed_url.scheme
+    return scheme and scheme == 'https' and location \
+           and location in ['jenkins.tribler.org', 'jenkins-ci.tribler.org']
+
+
+def get_artifact_name_from_url(parsed_url: ParseResult) -> str:
+    parsed_path = parsed_url.path
+    parsed_path = parsed_path[:-1] if parsed_path[-1] == '/' else parsed_path
+    splited_paths = parsed_path.split("/")
+    return splited_paths[-1] if splited_paths else None
+
+
+def get_jenkins_job_build_url(job_url):
+    build_json = json.loads(requests.get(f'{job_url}/api/json').text)
+    build_number = build_json['lastCompletedBuild']['number']
+    return f'{job_url}/{build_number}'
+
+
+def get_jenkins_build_artifacts(build_url):
+    build_json = json.loads(requests.get('%s/api/json' % build_url).text)
+    return build_json['artifacts'] if build_json and 'artifacts' in build_json else None
+
+
+def get_jenkins_build_artifact_hash(build_url, extension):
+    sha256_file_url = f'{build_url}/artifact/SHA256.txt'
+    sha256_file_path = save_artifact_to_workspace(sha256_file_url, 'SHA256.txt')
+    sha256_hash = get_sha256_for_type(sha256_file_path, extension)
+    return sha256_hash
 
 
 def fetch_latest_build_artifact(job_url, build_type):
     job_url = job_url[:-1] if job_url[-1] == '/' else job_url
-    build_number = fetch_latest_build_number(job_url)
-    build_url = '%s/%d' % (job_url, build_number)
-    last_build_json = json.loads(requests.get('%s/api/json' % build_url).text)
-    if not last_build_json['artifacts']:
+    parsed_url = urlparse(job_url)
+
+    if is_valid_artifact_url(parsed_url, build_type):
+        artifact_name = get_artifact_name_from_url(parsed_url)
+        artifact_hash = None  # No separate hash is made mandatory for external URLs
+        return save_artifact_to_workspace(job_url, artifact_name),  artifact_hash
+
+    elif is_valid_jenkins_url(parsed_url):
+        return fetch_latest_jenkins_build_artifact_and_hash(job_url, build_type)
+
+    print_and_exit("Did not find valid artifact URL")
+
+
+def fetch_latest_jenkins_build_artifact_and_hash(job_url, build_type):
+    build_url = get_jenkins_job_build_url(job_url)
+    artifacts = get_jenkins_build_artifacts(build_url)
+    if not artifacts:
         print_and_exit('No artifacts found!')
 
-    type_selector = '_x64.exe' if build_type == 'Win64' \
-        else 'x86.exe' if build_type == 'Win32' \
-        else '.deb' if build_type == 'Linux' \
-        else '.dmg' if build_type == 'MacOS' \
-        else None
+    expected_artifact_ext = get_artifact_extension(build_type)
+    if expected_artifact_ext:
+        selected_artifacts = [artifact for artifact in artifacts if expected_artifact_ext in artifact['fileName']]
+        if not selected_artifacts:
+            print_and_exit(f"{expected_artifact_ext} is not present in the artifact list")
 
-    if type_selector:
-        artifacts = [artifact for artifact in last_build_json['artifacts'] if type_selector in artifact['fileName']]
-        if not artifacts:
-            print_and_exit("%s is not present in the artifact list" % type_selector)
-        artifact_url = '%s/artifact/%s' % (build_url, artifacts[0]['relativePath'])
+        # Save the artifact
+        artifact_url = f"{build_url}/artifact/{selected_artifacts[0]['relativePath']}"
+        saved_artifact_path = save_artifact_to_workspace(artifact_url, selected_artifacts[0]['fileName'])
 
-        # Download the SHA256 file
-        sha256_file_url = '%s/artifact/SHA256.txt' % build_url
-        sha256_file_path = save_artifact_to_workspace(sha256_file_url, 'SHA256.txt')
-        sha256_hash = get_sha256_for_type(sha256_file_path, type_selector)
-        if not sha256_hash:
-            print_and_exit("Could not find SHA256 hash for type %s" % type_selector)
-
-        return save_artifact_to_workspace(artifact_url, artifacts[0]['fileName']), sha256_hash
+        # Get the hash from SHA256 file
+        sha256_hash = get_jenkins_build_artifact_hash(build_url, expected_artifact_ext)
+        return saved_artifact_path, sha256_hash
 
     print_and_exit("Artifact type not selected. Supported types are [Win64, Win32, Linux, MacOS]")
 


### PR DESCRIPTION
The changes in this PR is targeted to allow externally hosted release artefacts (eg. Github) besides Tribler Jenkins to be used in Jenkins job. This is done so that the last released version from Github and the current latest from Jenkins can be deployed and tested simultaneously.

Related: https://github.com/Tribler/tribler/issues/5857